### PR TITLE
Fix UUIDObfuscation loop increment from 18 to 16 to include all bytes

### DIFF
--- a/Packages/Obfuscators/Obfuscators.go
+++ b/Packages/Obfuscators/Obfuscators.go
@@ -80,10 +80,10 @@ func UUIDObfuscation(shellcode string) (string, int, []string) {
 	var nonEmptyStrings []string
 	var finalResult string
 
-	// Iterate over the hex pairs in groups of 18.
-	for i := 0; i < len(hexPairs); i += 18 {
+	// Iterate over the hex pairs in groups of 16.
+	for i := 0; i < len(hexPairs); i += 16 {
 		// Determine the end of the current group.
-		end := i + 18
+		end := i + 16
 		if end > len(hexPairs) {
 			end = len(hexPairs)
 		}


### PR DESCRIPTION
The UUID Obfuscation always fetches 18 bytes. 
The UUID only requires 16 bytes. So 2 bytes go missing on every iteration. 
Should be fixed by adjusting the increment to 16. 